### PR TITLE
Support dot, tuple and vect in the grammar

### DIFF
--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -39,7 +39,7 @@ function interpret(tab::SymbolTable, ex::Expr)
             return tab[args[1]](interpret.(Ref(tab),args[2:end])...)
         end
     elseif ex.head == :(.)
-        return Base.materialize(Base.broadcasted(Base.eval(args[1]), interpret(tab, args[2])...))
+        return Base.broadcast(Base.eval(args[1]), interpret(tab, args[2])...)
     elseif ex.head == :tuple
         return tuple(interpret.(Ref(tab), args)...)
     elseif ex.head == :vect

--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -38,6 +38,12 @@ function interpret(tab::SymbolTable, ex::Expr)
         else
             return tab[args[1]](interpret.(Ref(tab),args[2:end])...)
         end
+    elseif ex.head == :(.)
+        return Base.materialize(Base.broadcasted(Base.eval(args[1]), interpret(tab, args[2])...))
+    elseif ex.head == :tuple
+        return tuple(interpret.(Ref(tab), args)...)
+    elseif ex.head == :vect
+        return [interpret.(Ref(tab), args)...]
     elseif ex.head == :||
         return (interpret(tab, args[1]) || interpret(tab, args[2]))
     elseif ex.head == :&&

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -416,3 +416,12 @@ let
     interpret(S, ex) 
     Core.eval(S, ex)
 end
+
+let 
+    grammar = @grammar begin
+        Vector = [1, 2]
+        Vector = exp.(Vector)
+    end
+    tab = SymbolTable(grammar)
+    @test interpret(tab, :(exp.([1, 2]))) == exp.([1, 2])
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -423,5 +423,7 @@ let
         Vector = exp.(Vector)
     end
     tab = SymbolTable(grammar)
-    @test interpret(tab, :(exp.([1, 2]))) == exp.([1, 2])
+    tree = RuleNode(2, [RuleNode(1)])
+    ex = get_executable(tree, grammar)
+    interpret(tab, ex) == exp.([1, 2])
 end


### PR DESCRIPTION
This PR resolves https://github.com/sisl/ExprRules.jl/issues/18 and also supports `Expr` with a head of `tuple` and `vect` in the gammar now. See a minimal example in the test case.