### PR TITLE
Fixes an error related to depth-limit in grammars without terminal rules

### DIFF
--- a/src/ExprRules.jl
+++ b/src/ExprRules.jl
@@ -432,9 +432,11 @@ Generates a random RuleNode of return type typ and maximum depth max_depth.
 function Base.rand(::Type{RuleNode}, grammar::Grammar, typ::Symbol, max_depth::Int=10, 
     bin::Union{NodeRecycler,Nothing}=nothing)
     rules = grammar[typ]
-    rule_index = max_depth > 1 ?
+    
+    terminals = filter(r->isterminal(grammar,r), rules)
+    rule_index = max_depth > 1  || isempty(terminals) ?
         StatsBase.sample(rules) :
-        StatsBase.sample(filter(r->isterminal(grammar,r), rules))
+        StatsBase.sample(terminals)
 
     rulenode = iseval(grammar, rule_index) ?
         RuleNode(bin, rule_index, Core.eval(grammar, rule_index)) :

--- a/src/ExprRules.jl
+++ b/src/ExprRules.jl
@@ -433,10 +433,12 @@ function Base.rand(::Type{RuleNode}, grammar::Grammar, typ::Symbol, max_depth::I
     bin::Union{NodeRecycler,Nothing}=nothing)
     rules = grammar[typ]
     
-    terminals = filter(r->isterminal(grammar,r), rules)
-    rule_index = max_depth > 1  || isempty(terminals) ?
-        StatsBase.sample(rules) :
-        StatsBase.sample(terminals)
+    if max_depth <= 1
+        terminals = filter(r->isterminal(grammar,r), rules)
+        rule_index = !isempty(terminals) ? StatsBase.sample(terminals) : StatsBase.sample(rules)
+    else    
+        rule_index = StatsBase.sample(rules)
+    end
 
     rulenode = iseval(grammar, rule_index) ?
         RuleNode(bin, rule_index, Core.eval(grammar, rule_index)) :

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -427,3 +427,14 @@ let
     ex = get_executable(tree, grammar)
     interpret(tab, ex) == exp.([1, 2])
 end
+
+let
+    grammar = @grammar begin
+        A = B
+        B = C
+        C = D
+        D = E
+        E = 1
+    end
+    rulenode = rand(RuleNode, grammar, :A, 1)
+end


### PR DESCRIPTION
When we have a grammar where not every type has a terminal rule, setting a depth limit when sampling expressions can cause an error. For example, the grammar
```
grammar = @grammar begin
        A = B
        B = C
        C = D
        D = E
        E = 1
    end
```
will cause an error when we sample with a depth limit of 1 i.e. `rulenode = rand(RuleNode, grammar, :A, 1)`. 

I changed the logic so that if the depth limit is reached and a terminal rule is available then choose that rule. If no terminal rules are available then it chooses from the available rules.  The example above is added as a test. 
