### PR TITLE
Added new interpreter rules for handling broadcast comparisons and logical operators

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -427,3 +427,12 @@ let
     ex = get_executable(tree, grammar)
     interpret(tab, ex) == exp.([1, 2])
 end
+
+let
+    S = SymbolTable(:x => [1,2,3], :y => [0,2,4], :b1 => [1,1,1], :b2=>[1,0,1])
+    @test all(interpret(S, Meta.parse("x .<= y")) .== [false, true, true])
+    @test all(interpret(S, Meta.parse("x .>= y")) .== [true, true, false])
+    @test all(interpret(S, Meta.parse("x .== y")) .== [false, true, false])
+    @test all(interpret(S, Meta.parse("b1 .& b2")) .== [true, false, true])
+    @test all(interpret(S, Meta.parse("b1 .| b2")) .== [true, true, true])
+end


### PR DESCRIPTION
Added rules and tests for handling the following comparisons and operators: `.<=`, `.>=`, `.==`, `.&`, `.|`