### PR TITLE
Make insert! mutating when replacing the root

### DIFF
--- a/src/ExprRules.jl
+++ b/src/ExprRules.jl
@@ -576,7 +576,9 @@ function Base.insert!(root::RuleNode, loc::NodeLoc, rulenode::RuleNode)
     if loc.i > 0
         parent.children[i] = rulenode
     else
-        root = rulenode
+        root.ind = rulenode.ind
+        root._val = rulenode._val
+        root.children = rulenode.children
     end
     return root
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -218,6 +218,18 @@ let
     Random.seed!(3)
     insert!(rulenode, loc, rand(RuleNode, grammar, :Real, 3))
 
+    node = RuleNode(1, [RuleNode(2), RuleNode(2)])
+    child_loc = NodeLoc(node, 1)
+    new = RuleNode(3)
+    inserted = insert!(node, child_loc, new)
+    @test node == inserted
+
+    node = RuleNode(1, [RuleNode(2), RuleNode(2)])
+    root_loc = NodeLoc(node, 0)
+    new = RuleNode(3)
+    inserted =  insert!(node, root_loc, new)
+    @test node == inserted
+
     Random.seed!(4)
     rulenode = RuleNode(3, [RuleNode(4), RuleNode(5)])
     for i in 1 : 10


### PR DESCRIPTION
Hello, thank you for developing this package.

`insert!()` is supposed to be a mutating function, but it isn't when trying to replace the root of a node. This is the current behavior:

``` julia
using ExprRules

node = RuleNode(1, [RuleNode(2), RuleNode(2)])
child_loc = NodeLoc(node, 1)
new = RuleNode(3)
insert!(node, child_loc, new)
# => 1{3, 2}
node
# => 1{3, 2}

node = RuleNode(1, [RuleNode(2), RuleNode(2)])
root_loc = NodeLoc(node, 0)
new = RuleNode(3)
insert!(node, root_loc, new)
# => 3,
node 
# => 1{2, 2}
```

This pull request addresses this issue and should not have any side effects.
With the old code you could reassign the object `node = insert!(node, root_loc, new)` to circumvent the problem, which will still work.