### PR TITLE
Fix Base.hash to use only the two-arg method

### DIFF
--- a/src/ExprRules.jl
+++ b/src/ExprRules.jl
@@ -296,7 +296,7 @@ function Base.:(==)(A::RuleNode, B::RuleNode)
         all(isequal(a,b) for (a,b) in zip(A.children, B.children))
 end
 
-function Base.hash(node::RuleNode, h::UInt=zero(UInt))
+function Base.hash(node::RuleNode, h::UInt)
     retval = hash(node.ind, h)
     for child in node.children
         retval = hash(child, retval)


### PR DESCRIPTION
Generated as part of an ecosystem-wide audit for one-arg hash methods.

`Base.hash` should only be extended via the two-arg method `hash(x, h::UInt)`.
Defining a one-arg `hash(x)` method, or giving the second argument a default
value, can lead to correctness bugs (hash contract violations when the seed
differs from the hard-coded default) and invalidation-related performance
issues. This is particularly necessary for Julia 1.13+ where the default hash
seed value will change.

This PR was generated with the assistance of generative AI.